### PR TITLE
sort edges during propagation to skip more edges

### DIFF
--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -171,11 +171,11 @@ struct ThreadConfig {
 
 struct PropagatorConfig {
     bool strict{false};
+    bool sort_edges{true};
     uint64_t mutex_size{0};
     uint64_t mutex_cutoff{10};
     uint64_t propagate_root{0};
     uint64_t propagate_budget{0};
-    bool sort_edges{true};
     PropagationMode mode{PropagationMode::Check};
     std::vector<ThreadConfig> thread_config;
 
@@ -1217,7 +1217,7 @@ public:
             }
         }
 
-        if (!conf_.sort_edges) {
+        if (conf_.sort_edges) {
             std::sort(state.todo_edges.begin(), state.todo_edges.end(), [&](int l, int r) {
                 return edges_[l].weight < edges_[r].weight;
             });

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -175,7 +175,7 @@ struct PropagatorConfig {
     uint64_t mutex_cutoff{10};
     uint64_t propagate_root{0};
     uint64_t propagate_budget{0};
-    bool no_sort_edges{false};
+    bool sort_edges{true};
     PropagationMode mode{PropagationMode::Check};
     std::vector<ThreadConfig> thread_config;
 
@@ -921,7 +921,7 @@ struct DLState {
     DLStats &stats;
     DifferenceLogicGraph<T> dl_graph;
     std::vector<literal_t> false_lits;
-    std::vector<int> todo_edges_;
+    std::vector<int> todo_edges;
     uint64_t propagate_root;
     uint64_t propagate_budget;
 };
@@ -1204,7 +1204,7 @@ public:
             }
             state.false_lits.clear();
         }
-        state.todo_edges_.clear();
+        state.todo_edges.clear();
         for (auto lit : changes) {
             auto it = lit_to_edges_.find(lit), ie = lit_to_edges_.end();
             if (state.dl_graph.can_propagate()) { disable_edge_by_lit(state, lit); }
@@ -1213,37 +1213,40 @@ public:
                 ctl.remove_watch(lit);
             }
             for (; it != ie && it->first == lit; ++it) {
-                if (state.dl_graph.edge_is_active(it->second)) state.todo_edges_.push_back(it->second);
+                if (state.dl_graph.edge_is_active(it->second)) state.todo_edges.push_back(it->second);
             }
         }
 
-        if (!conf_.no_sort_edges) {
-            std::sort(state.todo_edges_.begin(), state.todo_edges_.end(), [&](int l, int r) { return edges_[l].weight < edges_[r].weight; });
+        if (!conf_.sort_edges) {
+            std::sort(state.todo_edges.begin(), state.todo_edges.end(), [&](int l, int r) {
+                return edges_[l].weight < edges_[r].weight;
+            });
         }
 
-        for (auto edge : state.todo_edges_) {
+        for (auto edge : state.todo_edges) {
             if (state.dl_graph.edge_is_active(edge)) {
-            auto ret = state.dl_graph.add_edge(edge, [&](std::vector<int> const &neg_cycle) {
-                std::vector<literal_t> clause;
-                for (auto eid : neg_cycle) {
-                    auto lit = -edges_[eid].lit;
-                    if (ctl.assignment().is_true(lit)) { return true; }
-                    clause.emplace_back(lit);
-                }
-                return ctl.add_clause(clause) && ctl.propagate();
-            });
-            if (!ret) { return; }
-            bool propagate = (state.dl_graph.mode() >= PropagationMode::Strong) ||
-                (level < state.propagate_root) || (
-                    state.propagate_budget > 0 &&
-                    state.dl_graph.can_propagate() &&
-                    state.stats.propagate_cost_add + state.propagate_budget > state.stats.propagate_cost_from + state.stats.propagate_cost_to);
-            if (!propagate) { state.dl_graph.disable_propagate(); }
-            // if !propgate -> can no longer propagate!
-            if (propagate && !state.dl_graph.propagate(edge, ctl)) { return; }
+                auto ret = state.dl_graph.add_edge(edge, [&](std::vector<int> const &neg_cycle) {
+                    std::vector<literal_t> clause;
+                    for (auto eid : neg_cycle) {
+                        auto lit = -edges_[eid].lit;
+                        if (ctl.assignment().is_true(lit)) { return true; }
+                        clause.emplace_back(lit);
+                    }
+                    return ctl.add_clause(clause) && ctl.propagate();
+                });
+                if (!ret) { return; }
+                bool propagate = (state.dl_graph.mode() >= PropagationMode::Strong) ||
+                    (level < state.propagate_root) || (
+                        state.propagate_budget > 0 &&
+                        state.dl_graph.can_propagate() &&
+                        state.stats.propagate_cost_add + state.propagate_budget > state.stats.propagate_cost_from + state.stats.propagate_cost_to);
+                if (!propagate) { state.dl_graph.disable_propagate(); }
+                // if !propgate -> can no longer propagate!
+                if (propagate && !state.dl_graph.propagate(edge, ctl)) { return; }
             }
         }
     }
+
     void propagate(PropagateControl &ctl, LiteralSpan changes) override {
         if (ctl.assignment().decision_level() == 0) {
             auto &facts = facts_[ctl.thread_id()];

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -175,6 +175,7 @@ struct PropagatorConfig {
     uint64_t mutex_cutoff{10};
     uint64_t propagate_root{0};
     uint64_t propagate_budget{0};
+    bool no_sort_edges{false};
     PropagationMode mode{PropagationMode::Check};
     std::vector<ThreadConfig> thread_config;
 
@@ -920,6 +921,7 @@ struct DLState {
     DLStats &stats;
     DifferenceLogicGraph<T> dl_graph;
     std::vector<literal_t> false_lits;
+    std::vector<int> todo_edges_;
     uint64_t propagate_root;
     uint64_t propagate_budget;
 };
@@ -1202,7 +1204,7 @@ public:
             }
             state.false_lits.clear();
         }
-        std::vector<int> edges;
+        state.todo_edges_.clear();
         for (auto lit : changes) {
             auto it = lit_to_edges_.find(lit), ie = lit_to_edges_.end();
             if (state.dl_graph.can_propagate()) { disable_edge_by_lit(state, lit); }
@@ -1211,33 +1213,34 @@ public:
                 ctl.remove_watch(lit);
             }
             for (; it != ie && it->first == lit; ++it) {
-                edges.push_back(it->second);
+                if (state.dl_graph.edge_is_active(it->second)) state.todo_edges_.push_back(it->second);
             }
         }
 
-        /// TODO: this could be optimized by inserting elements in lit_to_edges in the right order and then only merging the lists
-        std::sort(edges.begin(), edges.end(), [&](int l, int r) { return edges_[l].weight < edges_[r].weight; });
+        if (!conf_.no_sort_edges) {
+            std::sort(state.todo_edges_.begin(), state.todo_edges_.end(), [&](int l, int r) { return edges_[l].weight < edges_[r].weight; });
+        }
 
-        for (auto edge : edges) {
+        for (auto edge : state.todo_edges_) {
             if (state.dl_graph.edge_is_active(edge)) {
-                auto ret = state.dl_graph.add_edge(edge, [&](std::vector<int> const &neg_cycle) {
-                    std::vector<literal_t> clause;
-                    for (auto eid : neg_cycle) {
-                        auto lit = -edges_[eid].lit;
-                        if (ctl.assignment().is_true(lit)) { return true; }
-                        clause.emplace_back(lit);
-                    }
-                    return ctl.add_clause(clause) && ctl.propagate();
-                });
-                if (!ret) { return; }
-                bool propagate = (state.dl_graph.mode() >= PropagationMode::Strong) ||
-                    (level < state.propagate_root) || (
-                        state.propagate_budget > 0 &&
-                        state.dl_graph.can_propagate() &&
-                        state.stats.propagate_cost_add + state.propagate_budget > state.stats.propagate_cost_from + state.stats.propagate_cost_to);
-                if (!propagate) { state.dl_graph.disable_propagate(); }
-                // if !propgate -> can no longer propagate!
-                if (propagate && !state.dl_graph.propagate(edge, ctl)) { return; }
+            auto ret = state.dl_graph.add_edge(edge, [&](std::vector<int> const &neg_cycle) {
+                std::vector<literal_t> clause;
+                for (auto eid : neg_cycle) {
+                    auto lit = -edges_[eid].lit;
+                    if (ctl.assignment().is_true(lit)) { return true; }
+                    clause.emplace_back(lit);
+                }
+                return ctl.add_clause(clause) && ctl.propagate();
+            });
+            if (!ret) { return; }
+            bool propagate = (state.dl_graph.mode() >= PropagationMode::Strong) ||
+                (level < state.propagate_root) || (
+                    state.propagate_budget > 0 &&
+                    state.dl_graph.can_propagate() &&
+                    state.stats.propagate_cost_add + state.propagate_budget > state.stats.propagate_cost_from + state.stats.propagate_cost_to);
+            if (!propagate) { state.dl_graph.disable_propagate(); }
+            // if !propgate -> can no longer propagate!
+            if (propagate && !state.dl_graph.propagate(edge, ctl)) { return; }
             }
         }
     }

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -368,6 +368,9 @@ extern "C" bool clingodl_configure(clingodl_theory_t *theory, char const *key, c
         if (strcmp(key, "add-mutexes") == 0) {
             return check_parse("add-mutexes", parse_mutex(value, &theory->config));
         }
+        if (strcmp(key, "no-do-sort-edges") == 0) {
+            return check_parse("no-do-sort-edges", parse_bool(value, &theory->config.no_sort_edges));
+        }
         if (strcmp(key, "rdl") == 0) {
             return check_parse("rdl", parse_bool(value, &theory->rdl));
         }
@@ -414,6 +417,7 @@ extern "C" bool clingodl_register_options(clingodl_theory_t *theory, clingo_opti
             "      <max>   : Maximum size of mutexes to add\n"
             "      <cut>   : Limit costs to calculate mutexes\n",
             &parse_mutex, &theory->config, true, "<arg>"));
+        CLINGO_CALL(clingo_options_add_flag(options, group, "no-do-sort-edges", "Do not sort edges by lowest weight for propagation", &theory->config.no_sort_edges));
         CLINGO_CALL(clingo_options_add_flag(options, group, "rdl", "Enable support for real numbers", &theory->rdl));
         CLINGO_CALL(clingo_options_add_flag(options, group, "strict", "Enable strict mode", &theory->config.strict));
     }

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -417,7 +417,7 @@ extern "C" bool clingodl_register_options(clingodl_theory_t *theory, clingo_opti
             "      <max>   : Maximum size of mutexes to add\n"
             "      <cut>   : Limit costs to calculate mutexes\n",
             &parse_mutex, &theory->config, true, "<arg>"));
-        CLINGO_CALL(clingo_options_add_flag(options, group, "sort-edges", "Sort edges by lowest weight for propagation (default)", &theory->config.sort_edges));
+        CLINGO_CALL(clingo_options_add_flag(options, group, "sort-edges", "Sort edges by lowest weight for propagation [enabled]", &theory->config.sort_edges));
         CLINGO_CALL(clingo_options_add_flag(options, group, "rdl", "Enable support for real numbers", &theory->rdl));
         CLINGO_CALL(clingo_options_add_flag(options, group, "strict", "Enable strict mode", &theory->config.strict));
     }

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -368,8 +368,8 @@ extern "C" bool clingodl_configure(clingodl_theory_t *theory, char const *key, c
         if (strcmp(key, "add-mutexes") == 0) {
             return check_parse("add-mutexes", parse_mutex(value, &theory->config));
         }
-        if (strcmp(key, "no-do-sort-edges") == 0) {
-            return check_parse("no-do-sort-edges", parse_bool(value, &theory->config.no_sort_edges));
+        if (strcmp(key, "sort-edges") == 0) {
+            return check_parse("sort-edges", parse_bool(value, &theory->config.sort_edges));
         }
         if (strcmp(key, "rdl") == 0) {
             return check_parse("rdl", parse_bool(value, &theory->rdl));
@@ -417,7 +417,7 @@ extern "C" bool clingodl_register_options(clingodl_theory_t *theory, clingo_opti
             "      <max>   : Maximum size of mutexes to add\n"
             "      <cut>   : Limit costs to calculate mutexes\n",
             &parse_mutex, &theory->config, true, "<arg>"));
-        CLINGO_CALL(clingo_options_add_flag(options, group, "no-do-sort-edges", "Do not sort edges by lowest weight for propagation", &theory->config.no_sort_edges));
+        CLINGO_CALL(clingo_options_add_flag(options, group, "sort-edges", "Sort edges by lowest weight for propagation (default)", &theory->config.sort_edges));
         CLINGO_CALL(clingo_options_add_flag(options, group, "rdl", "Enable support for real numbers", &theory->rdl));
         CLINGO_CALL(clingo_options_add_flag(options, group, "strict", "Enable strict mode", &theory->config.strict));
     }


### PR DESCRIPTION
PR to talk about idea.
Sorting the edges that are added successively during one propagate call.
Idea:
Negative and small weights on the edge are more likely to produce:
1. negative cycles
2. changes of potential in the graph

By first adding edges with a lower weight, edges with smaller weights may be skipped afterwards.
What do you think? (First benchmarks on a small instance set show now difference)