### PR TITLE
Normalize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Enable folders in IDEs like Visual Studio
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Enable folders in IDEs like Visual Studio
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/libclingo-dl/CMakeLists.txt
+++ b/libclingo-dl/CMakeLists.txt
@@ -5,6 +5,8 @@ set(header-group
 source_group("${ide_header_group}" FILES ${header-group})
 set(header-group-clingo-dl
     "${CMAKE_CURRENT_SOURCE_DIR}/clingo-dl/propagator.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clingo-dl/astutil.hh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/clingo-dl/astutil_impl.hh"
     "${CMAKE_CURRENT_SOURCE_DIR}/clingo-dl/util.hh")
 source_group("${ide_header_group}\\clingo-dl" FILES ${header-group-clingo-dl})
 set(header
@@ -15,6 +17,7 @@ set(header
 set(ide_source_group "Source Files")
 set(source-group
     "${CMAKE_CURRENT_SOURCE_DIR}/src/clingo-dl.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/astutil.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/propagator.cc")
 source_group("${ide_source_group}" FILES ${source-group})
 set(source

--- a/libclingo-dl/clingo-dl/astutil.hh
+++ b/libclingo-dl/clingo-dl/astutil.hh
@@ -33,6 +33,7 @@
 //!
 //! @author Roland Kaminski
 
+namespace ClingoDL {
 
 //! Comparison operator to compare C strings.
 struct CStrCmp {
@@ -86,6 +87,7 @@ std::vector<Clingo::AST::BodyLiteral> unpool(Clingo::AST::BodyLiteral &&lit);
 //! Unpool theory atoms in statements.
 void unpool(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb);
 
+} // namespace ClingoDL
 
 #endif // CLINGODL_ASTUTIL_H
 

--- a/libclingo-dl/clingo-dl/astutil.hh
+++ b/libclingo-dl/clingo-dl/astutil.hh
@@ -1,0 +1,94 @@
+// {{{ MIT License
+//
+// Copyright 2020 Roland Kaminski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// }}}
+
+#ifndef CLINGODL_ASTUTIL_H
+#define CLINGODL_ASTUTIL_H
+
+#include <clingo.hh>
+#include <set>
+
+//! @file clingo-dl/astutil.hh
+//! Utility functions to work with ASTs.
+//!
+//! @author Roland Kaminski
+
+
+//! Comparison operator to compare C strings.
+struct CStrCmp {
+    inline bool operator()(char const *a, char const *b) const {
+        return std::strcmp(a, b) < 0;
+    }
+};
+//! Container to store variables.
+using VarSet = std::set<char const *, CStrCmp>;
+
+//! Visit an AST.
+template <typename V, typename N>
+void visit_ast(V&& v, N const &node);
+
+//! Visit and modify an AST.
+template <typename V, typename N>
+void transform_ast(V&& v, N &node);
+
+//! Collect variables in an AST.
+template <typename N>
+void collect_variables(VarSet &vars, N const &node);
+
+//! Collect variables in a sequence of ASTs.
+template <typename It>
+void collect_variables(VarSet &vars, It ib,It ie);
+
+//! Collect variables in an AST.
+template <typename N>
+VarSet collect_variables(N const &node);
+
+//! Collect variables in a sequence of ASTs.
+template <typename It>
+VarSet collect_variables(It ib,It ie);
+
+//! Calculate the crossproduct of a sequence of sequences.
+template <typename Seq, typename F>
+inline void cross_product(Seq seq, F f);
+
+//! Unpool the given term.
+std::vector<Clingo::AST::Term> unpool(Clingo::AST::Term &&term);
+
+//! Unpool the given literal.
+std::vector<Clingo::AST::Literal> unpool(Clingo::AST::Literal &&lit);
+
+//! Unpool theory atoms in the given head literal.
+std::vector<Clingo::AST::HeadLiteral> unpool(Clingo::AST::HeadLiteral &&lit);
+
+//! Unpool theory atoms in the given body literal.
+std::vector<Clingo::AST::BodyLiteral> unpool(Clingo::AST::BodyLiteral &&lit);
+
+//! Unpool theory atoms in statements.
+void unpool(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb);
+
+
+#endif // CLINGODL_ASTUTIL_H
+
+#ifndef CLINGODL_ASTUTIL_IMPL_H
+#include "clingo-dl/astutil_impl.hh"
+#endif

--- a/libclingo-dl/clingo-dl/astutil_impl.hh
+++ b/libclingo-dl/clingo-dl/astutil_impl.hh
@@ -27,6 +27,8 @@
 
 #include "clingo-dl/astutil.hh" // for completion
 
+namespace ClingoDL {
+
 namespace Detail {
 
 template <typename T, typename N, typename V, typename = void>
@@ -481,18 +483,18 @@ struct VarCollector {
 
 template <typename V, typename N>
 void transform_ast(V&& v, N &node) {
-    ::Detail::Visitor<V, false> vv{v};
+    ClingoDL::Detail::Visitor<V, false> vv{v};
     node.data.accept(vv, node);
 }
 template <typename V, typename N>
 void visit_ast(V&& v, N const &node) {
-    ::Detail::Visitor<V, true> vv{v};
+    ClingoDL::Detail::Visitor<V, true> vv{v};
     node.data.accept(vv, node);
 }
 
 template <typename N>
 void collect_variables(VarSet &vars, N const &node) {
-    ::Detail::VarCollector v{vars};
+    ClingoDL::Detail::VarCollector v{vars};
     visit_ast(v, node);
 }
 
@@ -524,5 +526,7 @@ inline void cross_product(Seq seq, F f) {
 }
 
 // }}}
+
+} // namespace ClingoDL
 
 #endif

--- a/libclingo-dl/clingo-dl/astutil_impl.hh
+++ b/libclingo-dl/clingo-dl/astutil_impl.hh
@@ -1,0 +1,528 @@
+// {{{ MIT License
+//
+// Copyright 2020 Roland Kaminski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// }}}
+
+#ifndef CLINGODL_ASTUTIL_IMPL_H
+#define CLINGODL_ASTUTIL_IMPL_H
+
+#include "clingo-dl/astutil.hh" // for completion
+
+namespace Detail {
+
+template <typename T, typename N, typename V, typename = void>
+struct has_visit : std::false_type { };
+
+template< class... >
+using cpp14_void_t = void;
+
+template <typename T, typename N, typename V>
+struct has_visit<T, N, V, cpp14_void_t<decltype(std::declval<T>().visit(std::declval<N>(), std::declval<V>()))>> : std::true_type { };
+
+template <typename T, typename N, typename V, typename std::enable_if<has_visit<T, N, V>::value, int>::type = 0>
+bool call_visit(T& t, N&& node, V&& value) {
+    t.visit(std::forward<N>(node), std::forward<V>(value));
+    return false;
+}
+
+template <typename T, typename N, typename V, typename std::enable_if<!has_visit<T, N, V>::value, int>::type = 0>
+bool call_visit(T& t, N&& node, V&& value) {
+    static_cast<void>(t);
+    static_cast<void>(node);
+    static_cast<void>(value);
+    return true;
+}
+
+template <bool C, typename T>
+using make_const_t = std::conditional_t<C, std::add_const_t<T>, T>;
+
+template <typename V, bool Const>
+struct Visitor {
+
+    template <class T>
+    void accept(T &value) {
+        value.data.accept(*this, value);
+    }
+
+    // terms
+    void visit(make_const_t<Const, Clingo::Symbol> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Variable> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::UnaryOperation> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.argument);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::BinaryOperation> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.left);
+            accept(value.right);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Interval> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.left);
+            accept(value.right);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Function> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &argument : value.arguments) {
+                accept(argument);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Pool> &value, make_const_t<Const, Clingo::AST::Term> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &argument : value.arguments) {
+                accept(argument);
+            }
+        }
+    }
+
+    // literals
+    void visit(make_const_t<Const, Clingo::AST::Boolean> &value, make_const_t<Const, Clingo::AST::Literal> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Term> &value, make_const_t<Const, Clingo::AST::Literal> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Comparison> &value, make_const_t<Const, Clingo::AST::Literal> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.left);
+            accept(value.right);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::CSPLiteral> &value, make_const_t<Const, Clingo::AST::Literal> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &term : value.term.terms) {
+                accept(term.coefficient);
+                if (auto *variable = term.variable.get()) {
+                    accept(*variable);
+                }
+            }
+            for (auto &guard : value.guards) {
+                for (auto &term : guard.term.terms) {
+                    accept(term.coefficient);
+                    if (auto *variable = term.variable.get()) {
+                        accept(*variable);
+                    }
+                }
+            }
+        }
+    }
+
+    // theory terms
+    void visit(make_const_t<Const, Clingo::Symbol> &value, make_const_t<Const, Clingo::AST::TheoryTerm> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Variable> &value, make_const_t<Const, Clingo::AST::TheoryTerm> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryTermSequence> &value, make_const_t<Const, Clingo::AST::TheoryTerm> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &term : value.terms) {
+                accept(term);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryFunction> &value, make_const_t<Const, Clingo::AST::TheoryTerm> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &term : value.arguments) {
+                accept(term);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryUnparsedTerm> &value, make_const_t<Const, Clingo::AST::TheoryTerm> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &element : value.elements) {
+                accept(element.term);
+            }
+        }
+    }
+
+    // head literals
+    void visit(make_const_t<Const, Clingo::AST::Literal> &value, make_const_t<Const, Clingo::AST::HeadLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Disjunction> &value, make_const_t<Const, Clingo::AST::HeadLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &condlit : value.elements) {
+                accept(condlit.literal);
+                for (auto &literal : condlit.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Aggregate> &value, make_const_t<Const, Clingo::AST::HeadLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            if (auto *guard = value.left_guard.get()) {
+                accept(guard->term);
+            }
+            if (auto *guard = value.right_guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                accept(element.literal);
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::HeadAggregate> &value, make_const_t<Const, Clingo::AST::HeadLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            if (auto *guard = value.left_guard.get()) {
+                accept(guard->term);
+            }
+            if (auto *guard = value.right_guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                for (auto &term : element.tuple) {
+                    accept(term);
+                }
+                accept(element.condition.literal);
+                for (auto &literal : element.condition.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryAtom> &value, make_const_t<Const, Clingo::AST::HeadLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.term);
+            if (auto *guard = value.guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                for (auto &term : element.tuple) {
+                    accept(term);
+                }
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    // body literals
+    void visit(make_const_t<Const, Clingo::AST::Literal> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::ConditionalLiteral> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.literal);
+            for (auto &literal : value.condition) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Aggregate> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            if (auto *guard = value.left_guard.get()) {
+                accept(guard->term);
+            }
+            if (auto *guard = value.right_guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                accept(element.literal);
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::BodyAggregate> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            if (auto *guard = value.left_guard.get()) {
+                accept(guard->term);
+            }
+            if (auto *guard = value.right_guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                for (auto &term : element.tuple) {
+                    accept(term);
+                }
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryAtom> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.term);
+            if (auto *guard = value.guard.get()) {
+                accept(guard->term);
+            }
+            for (auto &element : value.elements) {
+                for (auto &term : element.tuple) {
+                    accept(term);
+                }
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Disjoint> &value, make_const_t<Const, Clingo::AST::BodyLiteral> &node) {
+        if (call_visit(visitor, node, value)) {
+            for (auto &element : value.elements) {
+                for (auto &term : element.term.terms) {
+                    accept(term.coefficient);
+                    if (auto *variable = term.variable.get()) {
+                        accept(*variable);
+                    }
+                }
+                for (auto &term : element.tuple) {
+                    accept(term);
+                }
+                for (auto &literal : element.condition) {
+                    accept(literal);
+                }
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Rule> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.head);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Definition> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.value);
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::ShowSignature> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::ShowTerm> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.term);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Minimize> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.weight);
+            accept(value.priority);
+            for (auto &term : value.tuple) {
+                accept(term);
+            }
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Script> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Program> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::External> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.atom);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Edge> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.u);
+            accept(value.v);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Heuristic> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.atom);
+            accept(value.bias);
+            accept(value.modifier);
+            accept(value.priority);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::ProjectAtom> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+            accept(value.atom);
+            for (auto &literal : value.body) {
+                accept(literal);
+            }
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::ProjectSignature> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::TheoryDefinition> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    void visit(make_const_t<Const, Clingo::AST::Defined> &value, make_const_t<Const, Clingo::AST::Statement> &node) {
+        if (call_visit(visitor, node, value)) {
+        }
+    }
+
+    V &visitor;
+};
+
+template <typename It, typename V, typename F>
+inline void cross_product(It begin, It end, V &accu, F f) {
+    if (begin == end) {
+        f(accu.begin(), accu.end());
+    }
+    else {
+        for (auto &x : *begin++) {
+            accu.emplace_back(x);
+            // Note: recursion is avoidable but pools are usually small...
+            cross_product(begin, end, accu, f);
+            accu.pop_back();
+        }
+    }
+}
+
+struct VarCollector {
+    template <class T>
+    void visit(T const &node, Clingo::AST::Variable const &value) {
+        static_cast<void>(node);
+        vars.emplace(value.name);
+    }
+    VarSet &vars;
+};
+
+} // namespace Detail
+
+template <typename V, typename N>
+void transform_ast(V&& v, N &node) {
+    ::Detail::Visitor<V, false> vv{v};
+    node.data.accept(vv, node);
+}
+template <typename V, typename N>
+void visit_ast(V&& v, N const &node) {
+    ::Detail::Visitor<V, true> vv{v};
+    node.data.accept(vv, node);
+}
+
+template <typename N>
+void collect_variables(VarSet &vars, N const &node) {
+    ::Detail::VarCollector v{vars};
+    visit_ast(v, node);
+}
+
+template <typename It>
+void collect_variables(VarSet &vars, It ib,It ie) {
+    for (auto it = ib; it != ie; ++it) {
+        collect_variables(vars, *it);
+    }
+}
+
+template <typename N>
+VarSet collect_variables(N const &node) {
+    VarSet vars;
+    collect_variables(vars, node);
+    return vars;
+}
+
+template <typename It>
+VarSet collect_variables(It ib,It ie) {
+    VarSet vars;
+    collect_variables(vars, ib, ie);
+    return vars;
+}
+
+template <typename Seq, typename F>
+inline void cross_product(Seq seq, F f) {
+    std::vector<std::reference_wrapper<std::remove_reference_t<decltype(*begin(*begin(seq)))>>> accu;
+    Detail::cross_product(begin(seq), end(seq), accu, f);
+}
+
+// }}}
+
+#endif

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1315,10 +1315,10 @@ public:
         auto u_id = map_vert(Clingo::Number(0));
         auto v_id = map_vert(Clingo::Number(0));
         if (covec.size() == 0) {
-			if (rhs < 0) {
-				return init.add_clause({-literal});
-			}
-			return !strict || init.add_clause({literal});
+            if (rhs < 0) {
+                return init.add_clause({-literal});
+            }
+            return !strict || init.add_clause({literal});
         }
         else if (covec.size() == 1) {
             if (covec[0].first == 1) {

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -988,7 +988,7 @@ struct NodeInfo {
 };
 
 constexpr int INVALID_VAR{std::numeric_limits<int>::max()};
-[[nodiscard]] bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity);
+bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity);
 
 //! Test whether a variable is valid.
 inline bool is_valid_var(int var) {
@@ -1620,6 +1620,7 @@ private:
             return std::stod(a.string());
         }
         check_syntax(false);
+        return static_cast<T>(0); // remove warning
     }
 
     template <class F, class N, typename std::enable_if<std::is_integral<N>::value, int>::type = 0>

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1222,19 +1222,40 @@ public:
         if (covec.size() > 2) {
             throw std::runtime_error(msg);
         }
+//		for (auto i : covec) {
+//			std::cout << i.first << "*" << i.second;
+//		}
+//		std::cout << std::endl;
 
         auto u_id = map_vert(Clingo::Number(0));
         auto v_id = map_vert(Clingo::Number(0));
-        if (covec.size() > 0) {
-            if (covec[0].first != 0) throw std::runtime_error(msg);
-            u_id = covec[0].second;
+        if (covec.size() == 1) {
+            if (covec[0].first == 1) {
+				u_id = covec[0].second;
+			}
+			else if (covec[0].first == -1) {
+				v_id = covec[0].second;
+			}
+			else throw std::runtime_error(msg);
+        }
+		if (covec.size() == 2) {
+            if (covec[0].first == 1) {
+				u_id = covec[0].second;
+            	if (covec[1].first == -1) {
+					v_id = covec[0].second;
+				}
+				else throw std::runtime_error(msg);
+			}
+			else if (covec[0].first == -1) {
+				v_id = covec[0].second;
+            	if (covec[1].first == 1) {
+					u_id = covec[0].second;
+				}
+				else throw std::runtime_error(msg);
+			}
+			else throw std::runtime_error(msg);
         }
 
-        if (covec.size() > 1 && covec[1].first != -1) {
-            throw std::runtime_error(msg);
-            v_id = covec[1].second;
-        }
-        
         //if (term.type() != Clingo::TheoryTermType::Function || std::strcmp(term.name(), "-") != 0) {
         //    throw std::runtime_error(msg);
         //}
@@ -1583,7 +1604,7 @@ private:
         check_syntax(false);
     }
 
-    template <class F, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+    template <class F, class N, typename std::enable_if<std::is_integral<N>::value, int>::type = 0>
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F f) const {
         auto ea = evaluate(a);
         check_syntax(ea.type() == Clingo::SymbolType::Number);
@@ -1592,7 +1613,7 @@ private:
         return Clingo::Number(f(ea.number(), eb.number()));
     }
     
-    template <class F, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>
+    template <class F, class N, typename std::enable_if<std::is_floating_point<N>::value, int>::type = 0>
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F f) const {
         auto ea = evaluate(a);
         check_syntax(ea.type() == Clingo::SymbolType::String);
@@ -1600,6 +1621,11 @@ private:
         check_syntax(eb.type() == Clingo::SymbolType::String);
         //TODO: does Clingo copy string ?
         return Clingo::String(std::to_string(f(std::stod(ea.string()), std::stod(eb.string()))).c_str());
+    }
+
+    template <class F>
+    Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F &&f) const {
+        return evaluate<F, T>(a, b, std::forward<F>(f));
     }
 
 

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -41,18 +41,16 @@
 #define CHECKSOLUTION
 using namespace Clingo;
 
-namespace {
+namespace ClingoDL {
 template <typename T=void>
 T throw_syntax_error(char const *message="Invalid Syntax") {
     throw std::runtime_error(message);
 }
 
-void check_syntax(bool condition, char const *message="Invalid Syntax") {
+inline void check_syntax(bool condition, char const *message="Invalid Syntax") {
     if (!condition) {
         throw_syntax_error(message);
     }
-}
-
 }
 
 inline char const *negate_relation(char const *op) {
@@ -2082,5 +2080,6 @@ private:
     PropagatorConfig conf_;
 };
 
+} // namespace ClingoDL
 
 #endif // CLINGODL_PROPAGATOR_HH

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1293,14 +1293,16 @@ public:
 			else throw std::runtime_error(msg);
         }
 
+        add_edge(init, u_id, v_id, weight, lit);
+        if (conf_.strict) {
+            add_edge(init, v_id, u_id, -weight-1, -lit);
+        }
+    }
+
+    void add_edge(PropagateInit &init, int u_id, int v_id, T weight, int lit) {
         auto id = numeric_cast<int>(edges_.size());
         edges_.push_back({u_id, v_id, weight, lit});
         lit_to_edges_.emplace(lit, id);
-        if (conf_.strict) {
-            auto id = numeric_cast<int>(edges_.size());
-            edges_.push_back({v_id, u_id, -weight - 1, -lit});
-            lit_to_edges_.emplace(-lit, id);
-        }
         bool add = false;
         for (int i = 0; i < init.number_of_threads(); ++i) {
             init.add_watch(lit, i);
@@ -1308,15 +1310,9 @@ public:
                 add = true;
                 init.add_watch(-lit, i);
             }
-            else if (conf_.strict) {
-                init.add_watch(-lit, i);
-            }
         }
         if (add) {
             false_lit_to_edges_.emplace(-lit, id);
-            if (conf_.strict) {
-                false_lit_to_edges_.emplace(lit, id);
-            }
         }
     }
 

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1301,9 +1301,7 @@ public:
             parse_constraint_elem(element.tuple().front(), covec);
         }
         auto rhs = simplify(covec);
-
         normalize_constraint(init, lit, covec, rel, rhs, strict);
-
     }
 
     bool add_edge(PropagateInit& init, int literal, CoVarVec const &covec, T rhs, bool strict) {
@@ -1316,7 +1314,15 @@ public:
         }
         auto u_id = map_vert(Clingo::Number(0));
         auto v_id = map_vert(Clingo::Number(0));
-        if (covec.size() == 1) {
+        if (covec.size() == 0) {
+            int eval_lit = (0 <= rhs) ? 1 : -1;
+            if (!init.add_clause({-literal, eval_lit})) return false;
+            if (strict) {
+                if (!init.add_clause({-eval_lit, -literal})) return false;
+            }
+            return true;
+        }
+        else if (covec.size() == 1) {
             if (covec[0].first == 1) {
                 u_id = covec[0].second;
             }
@@ -1777,8 +1783,7 @@ private:
         if (a.type() == Clingo::SymbolType::String) {
             return std::stod(a.string());
         }
-        check_syntax(false);
-        return static_cast<T>(0); // remove warning
+        return throw_syntax_error<T>();
     }
 
     template <class F, class N, typename std::enable_if<std::is_integral<N>::value, int>::type = 0>
@@ -1794,9 +1799,7 @@ private:
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F f) const {
         auto ea = evaluate(a);
         auto eb = evaluate(b);
-        //TODO: does Clingo copy string ?
         return Clingo::String(std::to_string(f(to_T(ea), to_T(eb))).c_str());
-
     }
 
     template <class F>
@@ -1813,7 +1816,6 @@ private:
     T epsilon() const {
         return 0.00001;
     }
-
 
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &term) const {
         if (term.type() == Clingo::TheoryTermType::Symbol) {
@@ -1864,10 +1866,8 @@ private:
             }
             return Clingo::Function(term.type() == Clingo::TheoryTermType::Function ? term.name() : "", args);
         }
-
         return throw_syntax_error<Clingo::Symbol>();
     }
-
 
 private:
 

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1286,7 +1286,7 @@ public:
         auto rel = atom.guard().first;
 
         auto elems = atom.elements();
-        if (elems.size() != 1) {
+        if (elems.size() > 1) {
             throw std::runtime_error(msg);
         }
         for (auto const &element : elems) {

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -27,6 +27,7 @@
 
 #include <clingo.hh>
 #include <clingo-dl/util.hh>
+#include <clingo-dl/astutil.hh>
 
 #include <unordered_map>
 
@@ -39,6 +40,218 @@
 //#define CROSSCHECK
 #define CHECKSOLUTION
 using namespace Clingo;
+
+namespace {
+template <typename T=void>
+T throw_syntax_error(char const *message="Invalid Syntax") {
+    throw std::runtime_error(message);
+}
+
+void check_syntax(bool condition, char const *message="Invalid Syntax") {
+    if (!condition) {
+        throw_syntax_error(message);
+    }
+}
+
+}
+
+inline char const *negate_relation(char const *op) {
+    if (std::strcmp(op, "=") == 0) {
+        return "!=";
+    }
+    if (std::strcmp(op, "!=") == 0) {
+        return "=";
+    }
+    if (std::strcmp(op, "<") == 0) {
+        return ">=";
+    }
+    if (std::strcmp(op, "<=") == 0) {
+        return ">";
+    }
+    if (std::strcmp(op, ">") == 0) {
+        return "<=";
+    }
+    if (std::strcmp(op, ">=") == 0) {
+        return "<";
+    }
+    throw std::runtime_error("unexpected operator");
+}
+
+// Checks if the given theory atom is shiftable.
+struct SigMatcher {
+    template <typename CStr>
+    static bool visit(Clingo::Symbol const &f, CStr str) {
+        return f.match(str, 0);
+    }
+
+    template <typename CStr, typename... CStrs>
+    static bool visit(Clingo::Symbol const &f, CStr str, CStrs... strs) {
+        return (f.match(str, 0) || visit(f, strs...));
+    }
+
+    template <typename CStr>
+    static bool visit(Clingo::AST::Function const &f, CStr str) {
+        return !f.external && f.arguments.empty() && (std::strcmp(f.name, str) == 0);
+    }
+
+    template <typename CStr, typename... CStrs>
+    static bool visit(Clingo::AST::Function const &f, CStr str, CStrs... strs) {
+        return !f.external && f.arguments.empty() && ((std::strcmp(f.name, str) == 0) || visit(f, strs...));
+    }
+
+    template <class T, typename CStr>
+    static bool visit(T const &x, CStr str) {
+        static_cast<void>(x);
+        static_cast<void>(str);
+        return false;
+    }
+
+    template <class T, typename CStr, typename... CStrs>
+    static bool visit(T const &x, CStr str, CStrs... strs) {
+        static_cast<void>(x);
+        static_cast<void>(str);
+        return visit(x, strs...);
+    }
+};
+
+// Shifts constraints into rule heads.
+struct TheoryShifter {
+    static void visit(Clingo::AST::Rule &rule) {
+        if (!rule.head.data.is<Clingo::AST::Literal>()) {
+            return;
+        }
+        auto &head = rule.head.data.get<Clingo::AST::Literal>();
+        if (!head.data.is<Clingo::AST::Boolean>() || head.data.get<Clingo::AST::Boolean>().value) {
+            return;
+        }
+        auto it = rule.body.begin();
+        auto ie = rule.body.end();
+        auto jt = it;
+        for (; it != ie; ++it) {
+            if (it->data.is<Clingo::AST::TheoryAtom>()) {
+                auto &atom = it->data.get<Clingo::AST::TheoryAtom>();
+                SigMatcher matcher;
+                if (atom.term.data.accept(matcher, "diff")) {
+                    check_syntax(atom.guard.get() != nullptr);
+                    if (it->sign != Clingo::AST::Sign::Negation) {
+                        auto *guard = atom.guard.get();
+                        guard->operator_name = negate_relation(guard->operator_name);
+                    }
+                    rule.head.location = it->location;
+                    rule.head.data = std::move(atom);
+                    for (++it; it != ie; ++it, ++jt) {
+                        if (it != jt) {
+                            std::iter_swap(it, jt);
+                        }
+                    }
+                    break;
+                }
+            }
+            if (it != jt) {
+                std::iter_swap(it, jt);
+            }
+            ++jt;
+        }
+        rule.body.erase(jt, ie);
+    }
+
+    template <class T>
+    static void visit(T &value) {
+        static_cast<void>(value);
+    }
+};
+
+struct TermTagger {
+    static void visit(Clingo::AST::Function &term, char const *tag) {
+        std::string name{"__"};
+        name += term.name;
+        name += tag;
+        term.name = Clingo::add_string(name.c_str());
+    }
+
+    static void visit(Clingo::Symbol &term, char const *tag) {
+        std::string name{"__"};
+        name += term.name();
+        name += tag;
+        term = Clingo::Function(name.c_str(), {});
+    }
+
+    template <typename T>
+    static void visit(T &value, char const *tag) {
+        static_cast<void>(value);
+        static_cast<void>(tag);
+        throw_syntax_error();
+    }
+};
+
+
+// Tags head and body atoms and ensures multiset semantics.
+struct TheoryRewriter {
+    // Add variables to tuple to ensure multiset semantics.
+    static void rewrite_tuple(Clingo::AST::TheoryAtomElement &element, int number) {
+        check_syntax(element.tuple.size() == 1);
+        auto vars_condition = collect_variables(element.condition.begin(), element.condition.end());
+        for (auto const &name : collect_variables(element.tuple.begin(), element.tuple.end())) {
+            vars_condition.erase(name);
+        }
+        vars_condition.erase("_");
+        if (number >= 0) {
+            element.tuple.push_back({element.tuple.front().location, Clingo::Number(number)});
+        }
+        for (auto const &name : vars_condition) {
+            element.tuple.push_back({element.tuple.front().location, Clingo::AST::Variable{name}});
+        }
+    }
+
+    // Add variables to tuples of elements to ensure multiset semantics.
+    static void rewrite_tuples(Clingo::AST::TheoryAtom &atom) {
+        int number = atom.elements.size() > 1 ? 0 : -1;
+        for (auto &element : atom.elements) {
+            rewrite_tuple(element, number++);
+        }
+    }
+
+    static char const *tag(Clingo::AST::HeadLiteral const &lit) {
+        static_cast<void>(lit);
+        return "_h";
+    }
+
+    static char const *tag(Clingo::AST::BodyLiteral const &lit) {
+        static_cast<void>(lit);
+        return "_b";
+    }
+
+    // Mark head/body literals and ensure multiset semantics for theory atoms.
+    template <class Lit>
+    static void visit(Lit &node, Clingo::AST::TheoryAtom &atom) {
+        SigMatcher matcher;
+        if (atom.term.data.accept(matcher, "diff")) {
+            int number = atom.elements.size() > 1 ? 0 : -1;
+            for (auto &element : atom.elements) {
+                rewrite_tuple(element, number++);
+            }
+        }
+
+        if (atom.term.data.accept(matcher, "diff")) {
+            TermTagger tagger;
+            atom.term.data.accept(tagger, tag(node));
+        }
+    }
+};
+
+
+inline void transform(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb, bool shift) {
+    unpool(std::move(stm), [&](Clingo::AST::Statement &&unpooled) {
+        if (shift) {
+            TheoryShifter shifter;
+            unpooled.data.accept(shifter);
+        }
+        TheoryRewriter tagger;
+        transform_ast(tagger, unpooled);
+        cb(std::move(unpooled));
+    });
+}
+
 
 template <typename T>
 struct Edge {
@@ -172,7 +385,6 @@ struct ThreadConfig {
 };
 
 struct PropagatorConfig {
-    bool strict{false};
     SortMode sort_edges{SortMode::Weight};
     uint64_t mutex_size{0};
     uint64_t mutex_cutoff{10};
@@ -995,20 +1207,6 @@ inline bool is_valid_var(int var) {
     return var < INVALID_VAR;
 }
 
-namespace {
-template <typename T=void>
-T throw_syntax_error(char const *message="Invalid Syntax") {
-    throw std::runtime_error(message);
-}
-
-void check_syntax(bool condition, char const *message="Invalid Syntax") {
-    if (!condition) {
-        throw_syntax_error(message);
-    }
-}
-
-}
-
 
 
 template <typename T>
@@ -1037,7 +1235,7 @@ public:
         Timer t{stats_.time_init};
         for (auto atom : init.theory_atoms()) {
             auto term = atom.term();
-            if (term.to_string() == "diff") {
+            if (term.to_string() == "__diff_h" || term.to_string() == "__diff_b") {
                 add_edge_atom(init, atom);
             }
         }
@@ -1278,6 +1476,12 @@ public:
         if (!atom.has_guard()) {
             throw std::runtime_error(msg);
         }
+
+        auto term = atom.term();
+        bool strict = (term.to_string() == "__diff_b");
+        if (strict && std::is_floating_point<T>::value) {
+            std::runtime_error("real difference logic not available with strict semantics in the body of a rule");
+        }
         CoVarVec covec;
         parse_constraint_elem(atom.guard().second, covec);
         for (auto it = covec.begin(), ie = covec.end(); it != ie; ++it) {
@@ -1296,7 +1500,7 @@ public:
         }
         auto rhs = simplify(covec);
 
-        normalize_constraint(init, lit, covec, rel, rhs, conf_.strict);
+        normalize_constraint(init, lit, covec, rel, rhs, strict);
 
     }
 
@@ -1783,7 +1987,7 @@ private:
         check_syntax(eb.type() == Clingo::SymbolType::Number);
         return Clingo::Number(f(to_T(ea), to_T(eb)));
     }
-    
+
     template <class F, class N, typename std::enable_if<std::is_floating_point<N>::value, int>::type = 0>
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F f) const {
         auto ea = evaluate(a);
@@ -1797,7 +2001,7 @@ private:
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F &&f) const {
         return evaluate<F, T>(a, b, std::forward<F>(f));
     }
-    
+
     template <class N, typename std::enable_if<std::is_integral<N>::value, int>::type = 0>
     T epsilon() const {
         return 1;

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1315,12 +1315,10 @@ public:
         auto u_id = map_vert(Clingo::Number(0));
         auto v_id = map_vert(Clingo::Number(0));
         if (covec.size() == 0) {
-            int eval_lit = (0 <= rhs) ? 1 : -1;
-            if (!init.add_clause({-literal, eval_lit})) return false;
-            if (strict) {
-                if (!init.add_clause({-eval_lit, -literal})) return false;
-            }
-            return true;
+			if (rhs < 0) {
+				return init.add_clause({-literal});
+			}
+			return !strict || init.add_clause({literal});
         }
         else if (covec.size() == 1) {
             if (covec[0].first == 1) {

--- a/libclingo-dl/clingo-dl/util.hh
+++ b/libclingo-dl/clingo-dl/util.hh
@@ -41,7 +41,7 @@ struct hash<std::pair<int, int>> {
     }
 };
 
-}
+} // namespace std
 
 namespace Detail {
 

--- a/libclingo-dl/clingo-dl/util.hh
+++ b/libclingo-dl/clingo-dl/util.hh
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 namespace std {
 
@@ -204,5 +205,163 @@ private:
 private:
     std::vector<int> heap_;
 };
+
+
+// Some of the functions below could also be implemented using (much faster)
+// compiler specific built-ins. For more information check the following links:
+// - https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html
+// - https://wiki.sei.cmu.edu/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow
+
+//! Safely add a and b throwing an exception in case of overflow/underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_add(Int a, Int b) {
+    if (b > 0) {
+        if (a > std::numeric_limits<Int>::max() - b) {
+            throw std::overflow_error("integer overflow");
+        }
+    }
+    else if (b < 0) {
+        if (a < std::numeric_limits<Int>::min() - b) {
+            throw std::underflow_error("integer underflow");
+        }
+    }
+    return a + b;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_add(Float a, Float b) {
+	return a + b; 
+}
+
+//! Safely subtract a and b throwing an exception in case of
+//! overflow/underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_sub(Int a, Int b) {
+    if (b > 0) {
+        if (a < std::numeric_limits<Int>::min() + b) {
+            throw std::underflow_error("integer underflow");
+        }
+    }
+    else if (b < 0) {
+        if (a > std::numeric_limits<Int>::max() + b) {
+            throw std::overflow_error("integer overflow");
+        }
+    }
+    return a - b;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_sub(Float a, Float b) {
+	return a - b; 
+}
+
+//! Safely multiply a and b throwing an exception in case of
+//! overflow/underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_mul(Int a, Int b) {
+    if (a > 0) {
+        if (b > 0) {
+            if (a > (std::numeric_limits<Int>::max() / b)) {
+                throw std::overflow_error("integer overflow");
+            }
+        }
+        else if (b < (std::numeric_limits<Int>::min() / a)) {
+            throw std::underflow_error("integer underflow");
+        }
+    } else {
+        if (b > 0) {
+            if (a < (std::numeric_limits<Int>::min() / b)) {
+                throw std::underflow_error("integer underflow");
+            }
+        } else if (a < 0 && b < (std::numeric_limits<Int>::max() / a)) {
+            throw std::overflow_error("integer overflow");
+        }
+    }
+    return a * b;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_mul(Float a, Float b) {
+	return a * b; 
+}
+
+//! Safely divide a and b throwing an exception in case of overflow/underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_div(Int a, Int b) {
+    if (a == std::numeric_limits<Int>::min() && b == -1) {
+        throw std::overflow_error("integer overflow");
+    }
+    if (b == 0) {
+        if (a < 0) {
+            throw std::underflow_error("integer underflow");
+        }
+        throw std::overflow_error("integer overflow");
+    }
+    return a / b;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_div(Float a, Float b) {
+	return a / b; 
+}
+
+
+//! Safely calculate the modulo of a and b throwing an exception in case of
+//! overflow/underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_mod(Int a, Int b) {
+    if (a == std::numeric_limits<Int>::min() && b == -1) {
+        throw std::overflow_error("integer overflow");
+    }
+    if (b == 0) {
+        if (a < 0) {
+            throw std::underflow_error("integer underflow");
+        }
+        throw std::overflow_error("integer overflow");
+    }
+    return a % b;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_mod(Float a, Float b) {
+	return fmod(a,b); 
+}
+
+//! Safely invert a throwing an exception in case of an underflow.
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_inv(Int a) {
+    if (a == std::numeric_limits<Int>::min()) {
+        throw std::overflow_error("integer overflow");
+    }
+    return -a;
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_inv(Float a) {
+	return -a; 
+}
+
+template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+Int safe_pow(Int a, Int b) {
+    if (a == 0) {
+        throw std::overflow_error("integer overflow");
+    }
+    auto ret = std::pow(static_cast<double>(a), b);
+    if (ret > std::numeric_limits<Int>::max()) {
+        throw std::overflow_error("integer overflow");
+    }
+    if (ret < std::numeric_limits<Int>::min()) {
+        throw std::underflow_error("integer underflow");
+    }
+    return static_cast<Int>(ret);
+}
+
+template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+Float safe_pow(Float a, Float b) {
+	return std::pow(a,b); 
+}
+
+
+
 
 #endif // CLINGODL_UTIL_HH

--- a/libclingo-dl/clingo-dl/util.hh
+++ b/libclingo-dl/clingo-dl/util.hh
@@ -213,7 +213,7 @@ private:
 // - https://wiki.sei.cmu.edu/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow
 
 //! Safely add a and b throwing an exception in case of overflow/underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_add(Int a, Int b) {
     if (b > 0) {
         if (a > std::numeric_limits<Int>::max() - b) {
@@ -228,14 +228,14 @@ Int safe_add(Int a, Int b) {
     return a + b;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_add(Float a, Float b) {
 	return a + b; 
 }
 
 //! Safely subtract a and b throwing an exception in case of
 //! overflow/underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_sub(Int a, Int b) {
     if (b > 0) {
         if (a < std::numeric_limits<Int>::min() + b) {
@@ -250,14 +250,14 @@ Int safe_sub(Int a, Int b) {
     return a - b;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_sub(Float a, Float b) {
 	return a - b; 
 }
 
 //! Safely multiply a and b throwing an exception in case of
 //! overflow/underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_mul(Int a, Int b) {
     if (a > 0) {
         if (b > 0) {
@@ -280,13 +280,13 @@ Int safe_mul(Int a, Int b) {
     return a * b;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_mul(Float a, Float b) {
 	return a * b; 
 }
 
 //! Safely divide a and b throwing an exception in case of overflow/underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_div(Int a, Int b) {
     if (a == std::numeric_limits<Int>::min() && b == -1) {
         throw std::overflow_error("integer overflow");
@@ -300,7 +300,7 @@ Int safe_div(Int a, Int b) {
     return a / b;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_div(Float a, Float b) {
 	return a / b; 
 }
@@ -308,7 +308,7 @@ Float safe_div(Float a, Float b) {
 
 //! Safely calculate the modulo of a and b throwing an exception in case of
 //! overflow/underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_mod(Int a, Int b) {
     if (a == std::numeric_limits<Int>::min() && b == -1) {
         throw std::overflow_error("integer overflow");
@@ -322,13 +322,13 @@ Int safe_mod(Int a, Int b) {
     return a % b;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_mod(Float a, Float b) {
 	return fmod(a,b); 
 }
 
 //! Safely invert a throwing an exception in case of an underflow.
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_inv(Int a) {
     if (a == std::numeric_limits<Int>::min()) {
         throw std::overflow_error("integer overflow");
@@ -336,12 +336,12 @@ Int safe_inv(Int a) {
     return -a;
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_inv(Float a) {
 	return -a; 
 }
 
-template <typename Int, std::enable_if_t<std::is_integral_v<Int>, int> = 0> 
+template <typename Int, typename std::enable_if<std::is_integral<Int>::value, int>::type = 0> 
 Int safe_pow(Int a, Int b) {
     if (a == 0) {
         throw std::overflow_error("integer overflow");
@@ -356,7 +356,7 @@ Int safe_pow(Int a, Int b) {
     return static_cast<Int>(ret);
 }
 
-template <typename Float, std::enable_if_t<std::is_floating_point_v<Float>, int> = 0>
+template <typename Float, typename std::enable_if<std::is_floating_point<Float>::value, int>::type = 0>
 Float safe_pow(Float a, Float b) {
 	return std::pow(a,b); 
 }

--- a/libclingo-dl/src/astutil.cc
+++ b/libclingo-dl/src/astutil.cc
@@ -1,0 +1,355 @@
+// {{{ MIT License
+//
+// Copyright 2020 Roland Kaminski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// }}}
+
+#include "clingo-dl/astutil.hh"
+
+namespace {
+
+// Unpooling could still be improved. Since this is tricky, the current
+// implementation simply checks if there is a pool in a statement and only
+// unpools it in this case. To improve the implementation, a term in a tuple
+// resulting from a cross product can be moved if all other terms are the last
+// from their pool.
+
+struct TermUnpooler {
+    using Ret = std::vector<Clingo::AST::Term>;
+
+    static Ret accept(Clingo::AST::Term &term) {
+        TermUnpooler v;
+        return term.data.accept(v, term);
+    }
+
+    static Ret visit(Clingo::Symbol &value, Clingo::AST::Term &node) {
+        static_cast<void>(value);
+        return {std::move(node)};
+    }
+
+    static Ret visit(Clingo::AST::Variable &value, Clingo::AST::Term &node) {
+        static_cast<void>(value);
+        return {std::move(node)};
+    }
+
+    static Ret visit(Clingo::AST::UnaryOperation &value, Clingo::AST::Term &node) {
+        Ret ret;
+        for (auto &argument : accept(value.argument)) {
+            ret.push_back({node.location, Clingo::AST::UnaryOperation{value.unary_operator, std::move(argument)}});
+        }
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::BinaryOperation &value, Clingo::AST::Term &node) {
+        Ret ret;
+        auto pool_left = accept(value.left);
+        auto pool_right = accept(value.right);
+        for (auto &left : pool_left) {
+            for (auto &right : pool_right) {
+                ret.push_back({node.location, Clingo::AST::BinaryOperation{value.binary_operator, left, right}});
+            }
+        }
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::Interval &value, Clingo::AST::Term &node) {
+        Ret ret;
+        auto pool_left = accept(value.left);
+        auto pool_right = accept(value.right);
+        for (auto &left : pool_left) {
+            for (auto &right : pool_right) {
+                ret.push_back({node.location, Clingo::AST::Interval{left, right}});
+            }
+        }
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::Function &value, Clingo::AST::Term &node) {
+        std::vector<Ret> pools;
+        for (auto &term : value.arguments) {
+            pools.emplace_back(accept(term));
+        }
+        Ret ret;
+        cross_product(pools, [&](auto it, auto ie){
+            ret.push_back({node.location, Clingo::AST::Function{value.name, {it, ie}, value.external}});
+        });
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::Pool &value, Clingo::AST::Term &node) {
+        static_cast<void>(node);
+        Ret ret;
+        for (auto &term : value.arguments) {
+            auto pool = accept(term);
+            std::move(pool.begin(), pool.end(), std::back_inserter(ret));
+        }
+        return ret;
+    }
+};
+
+struct LiteralUnpooler {
+    using Ret = std::vector<Clingo::AST::Literal>;
+
+    static Ret visit(Clingo::AST::Boolean &value, Clingo::AST::Literal &node) {
+        static_cast<void>(value);
+        return {std::move(node)};
+    }
+
+    static Ret visit(Clingo::AST::Term &value, Clingo::AST::Literal &node) {
+        Ret ret;
+        for (auto &term : unpool(std::move(value))) {
+            ret.push_back({node.location, node.sign, std::move(term)});
+        }
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::Comparison &value, Clingo::AST::Literal &node) {
+        Ret ret;
+        auto pool_left = unpool(std::move(value.left));
+        auto pool_right = unpool(std::move(value.right));
+        for (auto &left : pool_left) {
+            for (auto &right : pool_right) {
+                ret.push_back({node.location, node.sign, Clingo::AST::Comparison{value.comparison, left, right}});
+            }
+        }
+        return ret;
+    }
+
+    static Ret visit(Clingo::AST::CSPLiteral &value, Clingo::AST::Literal &node) {
+        static_cast<void>(value);
+        static_cast<void>(node);
+        throw std::runtime_error("not implemented!!!");
+    }
+};
+
+void unpool_elements(Clingo::AST::TheoryAtom &atom) {
+    std::vector<Clingo::AST::TheoryAtomElement> elements;
+    std::swap(elements, atom.elements);
+    for (auto &element : elements) {
+        std::vector<std::vector<Clingo::AST::Literal>> pools;
+        for (auto &lit : element.condition) {
+            pools.emplace_back(unpool(std::move(lit)));
+        }
+        cross_product(pools, [&](auto it, auto ie){
+            atom.elements.push_back({element.tuple, {it, ie}});
+        });
+    }
+}
+
+struct HeadBodyUnpooler {
+    static std::vector<Clingo::AST::BodyLiteral> visit(Clingo::AST::TheoryAtom &value, Clingo::AST::BodyLiteral &lit) {
+        unpool_elements(value);
+        std::vector<Clingo::AST::BodyLiteral> ret;
+        for (auto &term : unpool(std::move(value.term))) {
+            ret.push_back({lit.location, lit.sign, Clingo::AST::TheoryAtom{std::move(term), value.elements, value.guard}});
+        }
+        return ret;
+    }
+
+    static std::vector<Clingo::AST::HeadLiteral> visit(Clingo::AST::TheoryAtom &value, Clingo::AST::HeadLiteral &lit) {
+        unpool_elements(value);
+        std::vector<Clingo::AST::HeadLiteral> ret;
+        for (auto &term : unpool(std::move(value.term))) {
+            ret.push_back({lit.location, Clingo::AST::TheoryAtom{std::move(term), value.elements, value.guard}});
+        }
+        return ret;
+    }
+
+    template <class T, class R>
+    static std::vector<R> visit(T &value, R &lit) {
+        static_cast<void>(value);
+        std::vector<R> ret;
+        ret.emplace_back(std::move(lit));
+        return ret;
+    }
+};
+
+std::vector<std::vector<Clingo::AST::BodyLiteral>> unpool_body(std::vector<Clingo::AST::BodyLiteral> &body) {
+    std::vector<std::vector<Clingo::AST::BodyLiteral>> pools;
+    pools.reserve(body.size());
+    for (auto &lit : body) {
+        pools.emplace_back(unpool(std::move(lit)));
+    }
+    return pools;
+}
+
+struct StatementUnpooler {
+    void visit(Clingo::AST::Rule &value, Clingo::AST::Statement &stm) const {
+        auto pools = unpool_body(value.body);
+        for (auto &lit : unpool(std::move(value.head))) {
+            cross_product(pools, [&](auto it, auto ie) {
+                callback({stm.location, Clingo::AST::Rule{lit, {it, ie}}});
+            });
+        }
+    }
+
+    void visit(Clingo::AST::Definition &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::ShowSignature &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::ShowTerm &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::ShowTerm{value.term, {it, ie}, value.csp}});
+        });
+    }
+
+    void visit(Clingo::AST::Minimize &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::Minimize{value.weight, value.priority, value.tuple, {it, ie}}});
+        });
+    }
+
+    void visit(Clingo::AST::Script &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::Program &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::External &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::External{value.atom, {it, ie}, value.type}});
+        });
+    }
+
+    void visit(Clingo::AST::Edge &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::Edge{value.u, value.v, {it, ie}}});
+        });
+    }
+
+    void visit(Clingo::AST::Heuristic &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::Heuristic{value.atom, {it, ie}, value.bias, value.priority, value.modifier}});
+        });
+    }
+
+    void visit(Clingo::AST::ProjectAtom &value, Clingo::AST::Statement &stm) const {
+        cross_product(unpool_body(value.body), [&](auto it, auto ie) {
+            callback({stm.location, Clingo::AST::ProjectAtom{value.atom, {it, ie}}});
+        });
+    }
+
+    void visit(Clingo::AST::ProjectSignature &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::TheoryDefinition &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    void visit(Clingo::AST::Defined &value, Clingo::AST::Statement &stm) const {
+        static_cast<void>(value);
+        callback(std::move(stm));
+    }
+
+    Clingo::StatementCallback const &callback;
+};
+
+struct HasPool {
+    void visit(Clingo::AST::Term const &term, Clingo::AST::Pool const &pool) {
+        static_cast<void>(term);
+        static_cast<void>(pool);
+        found_pool = true;
+    }
+    bool found_pool{false};
+};
+
+template <class N>
+bool has_pool(N const &node) {
+    HasPool v;
+    visit_ast(v, node);
+    return v.found_pool;
+}
+
+struct TheoryHasPool {
+    void visit(Clingo::AST::BodyLiteral const &lit, Clingo::AST::TheoryAtom const &atom) {
+        static_cast<void>(atom);
+        found_pool = found_pool || has_pool(lit);
+    }
+    void visit(Clingo::AST::HeadLiteral const &lit, Clingo::AST::TheoryAtom const &atom) {
+        static_cast<void>(atom);
+        found_pool = found_pool || has_pool(lit);
+    }
+    bool found_pool{false};
+};
+
+template <class N>
+bool theory_has_pool(N const &node) {
+    TheoryHasPool v;
+    visit_ast(v, node);
+    return v.found_pool;
+}
+
+} // namespace
+
+std::vector<Clingo::AST::Term> unpool(Clingo::AST::Term &&term) {
+    if (has_pool(term)) {
+        return TermUnpooler::accept(term);
+    }
+    return {std::move(term)};
+}
+
+std::vector<Clingo::AST::Literal> unpool(Clingo::AST::Literal &&lit) {
+    if (has_pool(lit)) {
+        LiteralUnpooler v;
+        return lit.data.accept(v, lit);
+    }
+    return {std::move(lit)};
+}
+
+std::vector<Clingo::AST::HeadLiteral> unpool(Clingo::AST::HeadLiteral &&lit) {
+    if (theory_has_pool(lit)) {
+        HeadBodyUnpooler v;
+        return lit.data.accept(v, lit);
+    }
+    return {std::move(lit)};
+}
+
+std::vector<Clingo::AST::BodyLiteral> unpool(Clingo::AST::BodyLiteral &&lit) {
+    if (theory_has_pool(lit)) {
+        HeadBodyUnpooler v;
+        return lit.data.accept(v, lit);
+    }
+    return {std::move(lit)};
+}
+
+void unpool(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb) {
+    if (theory_has_pool(stm)) {
+        StatementUnpooler v{cb};
+        stm.data.accept(v, stm);
+    }
+    else {
+        cb(std::move(stm));
+    }
+}
+

--- a/libclingo-dl/src/astutil.cc
+++ b/libclingo-dl/src/astutil.cc
@@ -24,6 +24,8 @@
 
 #include "clingo-dl/astutil.hh"
 
+namespace ClingoDL {
+
 namespace {
 
 // Unpooling could still be improved. Since this is tricky, the current
@@ -353,3 +355,4 @@ void unpool(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb) {
     }
 }
 
+} // namespace ClingoDL

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -104,8 +104,8 @@ void set_value<int>(clingodl_value_t *variant, int value) {
 
 template<>
 void set_value<double>(clingodl_value_t *variant, double value) {
-    variant->type = clingodl_value_type_int;
-    variant->int_number = value;
+    variant->type = clingodl_value_type_double;
+    variant->double_number = value;
 }
 
 template<typename T>
@@ -121,7 +121,7 @@ term {
   / : 2, binary, left;
   - : 3, unary
 };
-&diff/0 : term, {<=}, term, any;
+&diff/0 : term, {<=,>=,<,>,=,!=}, term, any;
 &show_assignment/0 : term, directive
 }.)"));
         static clingo_propagator_t prop = {

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -121,7 +121,8 @@ term {
   / : 2, binary, left;
   - : 3, unary
 };
-&diff/0 : term, {<=,>=,<,>,=,!=}, term, any;
+&__diff_h/0 : term, {<=,>=,<,>,=,!=}, term, head;
+&__diff_b/0 : term, {<=,>=,<,>,=,!=}, term, body;
 &show_assignment/0 : term, directive
 }.)"));
         static clingo_propagator_t prop = {
@@ -206,8 +207,9 @@ private:
 
 struct clingodl_theory {
     std::unique_ptr<PropagatorFacade> clingodl{nullptr};
-    bool rdl;
     PropagatorConfig config;
+    bool rdl;
+    bool shift_constraints{true};
 };
 
 extern "C" bool clingodl_create(clingodl_theory_t **theory) {
@@ -228,8 +230,18 @@ extern "C" bool clingodl_register(clingodl_theory_t *theory, clingo_control_t* c
 }
 
 extern "C" bool clingodl_rewrite_statement(clingodl_theory_t *theory, clingo_ast_statement_t const *stm, clingodl_rewrite_callback_t add, void *data) {
-    static_cast<void>(theory);
-    return add(stm, data);
+    CLINGODL_TRY {
+        Clingo::StatementCallback cb = [&](Clingo::AST::Statement &&stm) {
+            transform(std::move(stm), [add, data](Clingo::AST::Statement &&stm){
+                Clingo::AST::Detail::ASTToC visitor;
+                auto x = stm.data.accept(visitor);
+                x.location = stm.location;
+                CLINGO_CALL(add(&x, data));
+            }, theory->shift_constraints);
+        };
+        Clingo::AST::Detail::convStatement(stm, cb);
+    }
+    CLINGODL_CATCH;
 }
 
 extern "C" bool clingodl_prepare(clingodl_theory_t *, clingo_control_t *) {
@@ -405,9 +417,6 @@ extern "C" bool clingodl_configure(clingodl_theory_t *theory, char const *key, c
         if (strcmp(key, "rdl") == 0) {
             return check_parse("rdl", parse_bool(value, &theory->rdl));
         }
-        if (strcmp(key, "strict") == 0) {
-            return check_parse("strict", parse_bool(value, &theory->config));
-        }
         std::ostringstream msg;
         msg << "invalid configuration key '" << key << "'";
         clingo_set_error(clingo_error_runtime, msg.str().c_str());
@@ -458,18 +467,12 @@ extern "C" bool clingodl_register_options(clingodl_theory_t *theory, clingo_opti
             "        potential-reversed : Sort by relative negative potential",
             &parse_sort, &theory->config, true, "<arg>"));
         CLINGO_CALL(clingo_options_add_flag(options, group, "rdl", "Enable support for real numbers", &theory->rdl));
-        CLINGO_CALL(clingo_options_add_flag(options, group, "strict", "Enable strict mode", &theory->config.strict));
     }
     CLINGODL_CATCH;
 }
 
 extern "C" bool clingodl_validate_options(clingodl_theory_t *theory) {
-    CLINGODL_TRY {
-        if (theory->config.strict && theory->rdl) {
-            throw std::runtime_error("real difference logic not available with strict semantics");
-        }
-    }
-    CLINGODL_CATCH;
+    return true;
 }
 
 extern "C" bool clingodl_on_model(clingodl_theory_t *theory, clingo_model_t* model) {

--- a/libclingo-dl/src/clingo-dl.cc
+++ b/libclingo-dl/src/clingo-dl.cc
@@ -27,6 +27,8 @@
 
 #include <sstream>
 
+namespace ClingoDL {
+
 #define CLINGODL_TRY try
 #define CLINGODL_CATCH catch (...){ Clingo::Detail::handle_cxx_error(); return false; } return true
 
@@ -204,6 +206,10 @@ private:
     Stats accu_;
     DifferenceLogicPropagator<T> prop_;
 };
+
+} // namespace ClingoDL
+
+using namespace ClingoDL;
 
 struct clingodl_theory {
     std::unique_ptr<PropagatorFacade> clingodl{nullptr};

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -140,7 +140,7 @@ int require_number(Clingo::Symbol sym) { return sym.type() == Clingo::SymbolType
 //    }
 //}
 
-[[nodiscard]] bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
+bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
     return (term.type() == Clingo::TheoryTermType::Symbol &&
         std::strcmp(term.name(), name) == 0 &&
         arity == 0) ||

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -155,7 +155,6 @@ struct TermTagger {
     }
 };
 
-
 // Tags head and body atoms and ensures multiset semantics.
 struct TheoryRewriter {
     // Add variables to tuple to ensure multiset semantics.

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -173,12 +173,10 @@ struct TheoryRewriter {
         SigMatcher matcher;
         if (atom.term.data.accept(matcher, "diff")) {
             TermTagger tagger;
-            if (atom.elements.size() > 1) {
-                throw_syntax_error("Can not have multiple tuples in a difference constraint.");
-            }
-            if (atom.elements.size() && atom.elements[0].condition.size()) {
-                throw_syntax_error("Conditions not allowed in a difference constraint.");
-            }
+            char const *msg = "Diff atoms must consist of a single term without conditions.";
+            check_syntax(atom.elements.size() == 1, msg);
+            auto &element = atom.elements.front();
+            check_syntax(element.condition.empty() && element.tuple.size() == 1, msg);
             atom.term.data.accept(tagger, tag(node));
         }
     }

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -23,7 +23,6 @@
 // // }}}
 
 #include <clingo-dl/propagator.hh>
-
 template <typename T>
 T evaluate_real(char const *);
 
@@ -47,105 +46,107 @@ double evaluate_real(char const *name) {
     return ret;
 }
 
-template <typename T>
-T evaluate(Clingo::TheoryTerm term) {
-    switch (term.type()) {
-        case Clingo::TheoryTermType::Number: {
-            return term.number();
-        }
-        case Clingo::TheoryTermType::Symbol: {
-            return evaluate_real<T>(term.name());
-        }
-        case Clingo::TheoryTermType::Function: {
-            auto args = term.arguments();
-            if (args.size() == 2) {
-                return evaluate_binary(term.name(), evaluate<T>(args[0]), evaluate<T>(args[1]));
-            }
-            if (args.size() == 1) {
-                if (std::strcmp(term.name(), "-") == 0) {
-                    return -evaluate<T>(args[0]);
-                }
-                else {
-                    throw std::runtime_error("could not evaluate term: unknown unary operator");
-                }
-            }
-            // [[fallthrough]]
-        }
-        default: { throw std::runtime_error("could not evaluate term: only numeric terms with basic arithmetic operations are supported"); }
-    }
-}
 
-template int evaluate<int>(Clingo::TheoryTerm term);
-template double evaluate<double>(Clingo::TheoryTerm term);
+//template <typename T>
+//T evaluate(Clingo::TheoryTerm term) {
+//    switch (term.type()) {
+//        case Clingo::TheoryTermType::Number: {
+//            return term.number();
+//        }
+//        case Clingo::TheoryTermType::Symbol: {
+//            return evaluate_real<T>(term.name());
+//        }
+//        case Clingo::TheoryTermType::Function: {
+//            auto args = term.arguments();
+//            if (args.size() == 2) {
+//                return evaluate_binary(term.name(), evaluate<T>(args[0]), evaluate<T>(args[1]));
+//            }
+//            if (args.size() == 1) {
+//                if (std::strcmp(term.name(), "-") == 0) {
+//                    return -evaluate<T>(args[0]);
+//                }
+//                else {
+//                    throw std::runtime_error("could not evaluate term: unknown unary operator");
+//                }
+//            }
+//            // [[fallthrough]]
+//        }
+//        default: { throw std::runtime_error("could not evaluate term: only numeric terms with basic arithmetic operations are supported"); }
+//    }
+//}
+//
+//template int evaluate<int>(Clingo::TheoryTerm term);
+//template double evaluate<double>(Clingo::TheoryTerm term);
 
 int require_number(Clingo::Symbol sym) { return sym.type() == Clingo::SymbolType::Number ? sym.number() : throw std::runtime_error("could not evaluate term: artithmetic on non-integer"); }
 
-template <>
-int get_weight(TheoryAtom const &atom) {
-    return evaluate<int>(atom.guard().second);
-}
-template <>
-double get_weight(TheoryAtom const &atom) {
-    return evaluate<double>(atom.guard().second);
+//extern Clingo::Symbol evaluate_term(Clingo::TheoryTerm term) {
+//    switch (term.type()) {
+//        case Clingo::TheoryTermType::Number: {
+//            return Clingo::Number(term.number());
+//        }
+//        case Clingo::TheoryTermType::Symbol: {
+//            return Clingo::Id(term.name(), true);
+//        }
+//        case Clingo::TheoryTermType::Function: {
+//            auto op = term.name();
+//            std::vector<Clingo::Symbol> args;
+//            for (auto arg : term.arguments()) {
+//                args.emplace_back(evaluate_term(arg));
+//            }
+//            if (args.size() == 2) {
+//                if (std::strcmp(op, "+") == 0) {
+//                    return Clingo::Number(require_number(args[0]) + require_number(args[1]));
+//                }
+//                else if (std::strcmp(op, "-") == 0) {
+//                    return Clingo::Number(require_number(args[0]) - require_number(args[1]));
+//                }
+//                else if (std::strcmp(op, "*") == 0) {
+//                    return Clingo::Number(require_number(args[0]) * require_number(args[1]));
+//                }
+//                else if (std::strcmp(op, "/") == 0) {
+//                    if (args[1] == Clingo::Number(0)) {
+//                        throw std::runtime_error("could not evaluate term: division by zero");
+//                    }
+//                    return Clingo::Number(require_number(args[0]) / require_number(args[1]));
+//                }
+//            }
+//            else if (args.size() == 1) {
+//                if (std::strcmp(op, "-") == 0) {
+//                    switch (args[0].type()) {
+//                        case Clingo::SymbolType::Number: {
+//                            return Clingo::Number(-args[0].number());
+//                        }
+//                        case Clingo::SymbolType::Function: {
+//                            if (std::strcmp(args[0].name(), "") != 0) {
+//                                return Clingo::Function(args[0].name(), args[0].arguments(), args[0].is_negative());
+//                            }
+//                            // [[fallthrough]]
+//                        }
+//                        default: { throw std::runtime_error("could not evaluate term: only numbers and functions can be inverted"); }
+//                    }
+//                }
+//            }
+//            return Clingo::Function(op, args);
+//        }
+//        case Clingo::TheoryTermType::Tuple: {
+//            std::vector<Clingo::Symbol> args;
+//            for (auto arg : term.arguments()) {
+//                args.emplace_back(evaluate_term(arg));
+//            }
+//            return Clingo::Function("", args);
+//        }
+//        default: { throw std::runtime_error("could not evaluate term: sets and lists are not supported"); }
+//    }
+//}
+
+[[nodiscard]] bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
+    return (term.type() == Clingo::TheoryTermType::Symbol &&
+        std::strcmp(term.name(), name) == 0 &&
+        arity == 0) ||
+        (term.type() == Clingo::TheoryTermType::Function &&
+        std::strcmp(term.name(), name) == 0 &&
+        term.arguments().size() == arity);
 }
 
-extern Clingo::Symbol evaluate_term(Clingo::TheoryTerm term) {
-    switch (term.type()) {
-        case Clingo::TheoryTermType::Number: {
-            return Clingo::Number(term.number());
-        }
-        case Clingo::TheoryTermType::Symbol: {
-            return Clingo::Id(term.name(), true);
-        }
-        case Clingo::TheoryTermType::Function: {
-            auto op = term.name();
-            std::vector<Clingo::Symbol> args;
-            for (auto arg : term.arguments()) {
-                args.emplace_back(evaluate_term(arg));
-            }
-            if (args.size() == 2) {
-                if (std::strcmp(op, "+") == 0) {
-                    return Clingo::Number(require_number(args[0]) + require_number(args[1]));
-                }
-                else if (std::strcmp(op, "-") == 0) {
-                    return Clingo::Number(require_number(args[0]) - require_number(args[1]));
-                }
-                else if (std::strcmp(op, "*") == 0) {
-                    return Clingo::Number(require_number(args[0]) * require_number(args[1]));
-                }
-                else if (std::strcmp(op, "/") == 0) {
-                    if (args[1] == Clingo::Number(0)) {
-                        throw std::runtime_error("could not evaluate term: division by zero");
-                    }
-                    return Clingo::Number(require_number(args[0]) / require_number(args[1]));
-                }
-            }
-            else if (args.size() == 1) {
-                if (std::strcmp(op, "-") == 0) {
-                    switch (args[0].type()) {
-                        case Clingo::SymbolType::Number: {
-                            return Clingo::Number(-args[0].number());
-                        }
-                        case Clingo::SymbolType::Function: {
-                            if (std::strcmp(args[0].name(), "") != 0) {
-                                return Clingo::Function(args[0].name(), args[0].arguments(), args[0].is_negative());
-                            }
-                            // [[fallthrough]]
-                        }
-                        default: { throw std::runtime_error("could not evaluate term: only numbers and functions can be inverted"); }
-                    }
-                }
-            }
-            return Clingo::Function(op, args);
-        }
-        case Clingo::TheoryTermType::Tuple: {
-            std::vector<Clingo::Symbol> args;
-            for (auto arg : term.arguments()) {
-                args.emplace_back(evaluate_term(arg));
-            }
-            return Clingo::Function("", args);
-        }
-        default: { throw std::runtime_error("could not evaluate term: sets and lists are not supported"); }
-    }
-}
 

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -23,122 +23,8 @@
 // // }}}
 
 #include <clingo-dl/propagator.hh>
-template <typename T>
-T evaluate_real(char const *);
 
-template <>
-int evaluate_real(char const *) {
-    throw std::runtime_error("could not evaluate term: integer expected");
-}
-
-template <>
-double evaluate_real(char const *name) {
-    static const std::string chars = "\"";
-    auto len = std::strlen(name);
-    if (len < 2 || name[0] != '"' || name[len - 1] != '"') {
-        throw std::runtime_error("could not evaluate term: real numbers have to be represented as strings");
-    }
-    char *parsed = nullptr;
-    auto ret = std::strtod(name + 1, &parsed);
-    if (parsed != name + len - 1) {
-        throw std::runtime_error("could not evaluate term: not a valid real number");
-    }
-    return ret;
-}
-
-
-//template <typename T>
-//T evaluate(Clingo::TheoryTerm term) {
-//    switch (term.type()) {
-//        case Clingo::TheoryTermType::Number: {
-//            return term.number();
-//        }
-//        case Clingo::TheoryTermType::Symbol: {
-//            return evaluate_real<T>(term.name());
-//        }
-//        case Clingo::TheoryTermType::Function: {
-//            auto args = term.arguments();
-//            if (args.size() == 2) {
-//                return evaluate_binary(term.name(), evaluate<T>(args[0]), evaluate<T>(args[1]));
-//            }
-//            if (args.size() == 1) {
-//                if (std::strcmp(term.name(), "-") == 0) {
-//                    return -evaluate<T>(args[0]);
-//                }
-//                else {
-//                    throw std::runtime_error("could not evaluate term: unknown unary operator");
-//                }
-//            }
-//            // [[fallthrough]]
-//        }
-//        default: { throw std::runtime_error("could not evaluate term: only numeric terms with basic arithmetic operations are supported"); }
-//    }
-//}
-//
-//template int evaluate<int>(Clingo::TheoryTerm term);
-//template double evaluate<double>(Clingo::TheoryTerm term);
-
-int require_number(Clingo::Symbol sym) { return sym.type() == Clingo::SymbolType::Number ? sym.number() : throw std::runtime_error("could not evaluate term: artithmetic on non-integer"); }
-
-//extern Clingo::Symbol evaluate_term(Clingo::TheoryTerm term) {
-//    switch (term.type()) {
-//        case Clingo::TheoryTermType::Number: {
-//            return Clingo::Number(term.number());
-//        }
-//        case Clingo::TheoryTermType::Symbol: {
-//            return Clingo::Id(term.name(), true);
-//        }
-//        case Clingo::TheoryTermType::Function: {
-//            auto op = term.name();
-//            std::vector<Clingo::Symbol> args;
-//            for (auto arg : term.arguments()) {
-//                args.emplace_back(evaluate_term(arg));
-//            }
-//            if (args.size() == 2) {
-//                if (std::strcmp(op, "+") == 0) {
-//                    return Clingo::Number(require_number(args[0]) + require_number(args[1]));
-//                }
-//                else if (std::strcmp(op, "-") == 0) {
-//                    return Clingo::Number(require_number(args[0]) - require_number(args[1]));
-//                }
-//                else if (std::strcmp(op, "*") == 0) {
-//                    return Clingo::Number(require_number(args[0]) * require_number(args[1]));
-//                }
-//                else if (std::strcmp(op, "/") == 0) {
-//                    if (args[1] == Clingo::Number(0)) {
-//                        throw std::runtime_error("could not evaluate term: division by zero");
-//                    }
-//                    return Clingo::Number(require_number(args[0]) / require_number(args[1]));
-//                }
-//            }
-//            else if (args.size() == 1) {
-//                if (std::strcmp(op, "-") == 0) {
-//                    switch (args[0].type()) {
-//                        case Clingo::SymbolType::Number: {
-//                            return Clingo::Number(-args[0].number());
-//                        }
-//                        case Clingo::SymbolType::Function: {
-//                            if (std::strcmp(args[0].name(), "") != 0) {
-//                                return Clingo::Function(args[0].name(), args[0].arguments(), args[0].is_negative());
-//                            }
-//                            // [[fallthrough]]
-//                        }
-//                        default: { throw std::runtime_error("could not evaluate term: only numbers and functions can be inverted"); }
-//                    }
-//                }
-//            }
-//            return Clingo::Function(op, args);
-//        }
-//        case Clingo::TheoryTermType::Tuple: {
-//            std::vector<Clingo::Symbol> args;
-//            for (auto arg : term.arguments()) {
-//                args.emplace_back(evaluate_term(arg));
-//            }
-//            return Clingo::Function("", args);
-//        }
-//        default: { throw std::runtime_error("could not evaluate term: sets and lists are not supported"); }
-//    }
-//}
+namespace ClingoDL {
 
 bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
     return (term.type() == Clingo::TheoryTermType::Symbol &&
@@ -149,4 +35,4 @@ bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
         term.arguments().size() == arity);
 }
 
-
+} // namespace ClingoDL

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -26,6 +26,204 @@
 
 namespace ClingoDL {
 
+char const *negate_relation(char const *op) {
+    if (std::strcmp(op, "=") == 0) {
+        return "!=";
+    }
+    if (std::strcmp(op, "!=") == 0) {
+        return "=";
+    }
+    if (std::strcmp(op, "<") == 0) {
+        return ">=";
+    }
+    if (std::strcmp(op, "<=") == 0) {
+        return ">";
+    }
+    if (std::strcmp(op, ">") == 0) {
+        return "<=";
+    }
+    if (std::strcmp(op, ">=") == 0) {
+        return "<";
+    }
+    throw std::runtime_error("unexpected operator");
+}
+
+// Checks if the given theory atom is shiftable.
+struct SigMatcher {
+    template <typename CStr>
+    static bool visit(Clingo::Symbol const &f, CStr str) {
+        return f.match(str, 0);
+    }
+
+    template <typename CStr, typename... CStrs>
+    static bool visit(Clingo::Symbol const &f, CStr str, CStrs... strs) {
+        return (f.match(str, 0) || visit(f, strs...));
+    }
+
+    template <typename CStr>
+    static bool visit(Clingo::AST::Function const &f, CStr str) {
+        return !f.external && f.arguments.empty() && (std::strcmp(f.name, str) == 0);
+    }
+
+    template <typename CStr, typename... CStrs>
+    static bool visit(Clingo::AST::Function const &f, CStr str, CStrs... strs) {
+        return !f.external && f.arguments.empty() && ((std::strcmp(f.name, str) == 0) || visit(f, strs...));
+    }
+
+    template <class T, typename CStr>
+    static bool visit(T const &x, CStr str) {
+        static_cast<void>(x);
+        static_cast<void>(str);
+        return false;
+    }
+
+    template <class T, typename CStr, typename... CStrs>
+    static bool visit(T const &x, CStr str, CStrs... strs) {
+        static_cast<void>(x);
+        static_cast<void>(str);
+        return visit(x, strs...);
+    }
+};
+
+// Shifts constraints into rule heads.
+struct TheoryShifter {
+    static void visit(Clingo::AST::Rule &rule) {
+        if (!rule.head.data.is<Clingo::AST::Literal>()) {
+            return;
+        }
+        auto &head = rule.head.data.get<Clingo::AST::Literal>();
+        if (!head.data.is<Clingo::AST::Boolean>() || head.data.get<Clingo::AST::Boolean>().value) {
+            return;
+        }
+        auto it = rule.body.begin();
+        auto ie = rule.body.end();
+        auto jt = it;
+        for (; it != ie; ++it) {
+            if (it->data.is<Clingo::AST::TheoryAtom>()) {
+                auto &atom = it->data.get<Clingo::AST::TheoryAtom>();
+                SigMatcher matcher;
+                if (atom.term.data.accept(matcher, "diff")) {
+                    check_syntax(atom.guard.get() != nullptr);
+                    if (it->sign != Clingo::AST::Sign::Negation) {
+                        auto *guard = atom.guard.get();
+                        guard->operator_name = negate_relation(guard->operator_name);
+                    }
+                    rule.head.location = it->location;
+                    rule.head.data = std::move(atom);
+                    for (++it; it != ie; ++it, ++jt) {
+                        if (it != jt) {
+                            std::iter_swap(it, jt);
+                        }
+                    }
+                    break;
+                }
+            }
+            if (it != jt) {
+                std::iter_swap(it, jt);
+            }
+            ++jt;
+        }
+        rule.body.erase(jt, ie);
+    }
+
+    template <class T>
+    static void visit(T &value) {
+        static_cast<void>(value);
+    }
+};
+
+struct TermTagger {
+    static void visit(Clingo::AST::Function &term, char const *tag) {
+        std::string name{"__"};
+        name += term.name;
+        name += tag;
+        term.name = Clingo::add_string(name.c_str());
+    }
+
+    static void visit(Clingo::Symbol &term, char const *tag) {
+        std::string name{"__"};
+        name += term.name();
+        name += tag;
+        term = Clingo::Function(name.c_str(), {});
+    }
+
+    template <typename T>
+    static void visit(T &value, char const *tag) {
+        static_cast<void>(value);
+        static_cast<void>(tag);
+        throw_syntax_error();
+    }
+};
+
+
+// Tags head and body atoms and ensures multiset semantics.
+struct TheoryRewriter {
+    // Add variables to tuple to ensure multiset semantics.
+    static void rewrite_tuple(Clingo::AST::TheoryAtomElement &element, int number) {
+        check_syntax(element.tuple.size() == 1);
+        auto vars_condition = collect_variables(element.condition.begin(), element.condition.end());
+        for (auto const &name : collect_variables(element.tuple.begin(), element.tuple.end())) {
+            vars_condition.erase(name);
+        }
+        vars_condition.erase("_");
+        if (number >= 0) {
+            element.tuple.push_back({element.tuple.front().location, Clingo::Number(number)});
+        }
+        for (auto const &name : vars_condition) {
+            element.tuple.push_back({element.tuple.front().location, Clingo::AST::Variable{name}});
+        }
+    }
+
+    // Add variables to tuples of elements to ensure multiset semantics.
+    static void rewrite_tuples(Clingo::AST::TheoryAtom &atom) {
+        int number = atom.elements.size() > 1 ? 0 : -1;
+        for (auto &element : atom.elements) {
+            rewrite_tuple(element, number++);
+        }
+    }
+
+    static char const *tag(Clingo::AST::HeadLiteral const &lit) {
+        static_cast<void>(lit);
+        return "_h";
+    }
+
+    static char const *tag(Clingo::AST::BodyLiteral const &lit) {
+        static_cast<void>(lit);
+        return "_b";
+    }
+
+    // Mark head/body literals and ensure multiset semantics for theory atoms.
+    template <class Lit>
+    static void visit(Lit &node, Clingo::AST::TheoryAtom &atom) {
+        SigMatcher matcher;
+        if (atom.term.data.accept(matcher, "diff")) {
+            int number = atom.elements.size() > 1 ? 0 : -1;
+            for (auto &element : atom.elements) {
+                rewrite_tuple(element, number++);
+            }
+        }
+
+        if (atom.term.data.accept(matcher, "diff")) {
+            TermTagger tagger;
+            atom.term.data.accept(tagger, tag(node));
+        }
+    }
+};
+
+
+void transform(Clingo::AST::Statement &&stm, Clingo::StatementCallback const &cb, bool shift) {
+    unpool(std::move(stm), [&](Clingo::AST::Statement &&unpooled) {
+        if (shift) {
+            TheoryShifter shifter;
+            unpooled.data.accept(shifter);
+        }
+        TheoryRewriter tagger;
+        transform_ast(tagger, unpooled);
+        cb(std::move(unpooled));
+    });
+}
+
+
 bool match(Clingo::TheoryTerm const &term, char const *name, size_t arity) {
     return (term.type() == Clingo::TheoryTermType::Symbol &&
         std::strcmp(term.name(), name) == 0 &&

--- a/libclingo-dl/tests/solve.cc
+++ b/libclingo-dl/tests/solve.cc
@@ -199,7 +199,7 @@ TEST_CASE("solving", "[clingo]") {
                 "#program base.\n"
                 "a :- &diff { a - a } <= 5.\n"
                 "{ b }.\n"
-                "&diff {} < -4 :- b.\n"
+                "&diff { 0 } < -4 :- b.\n"
                 );
             ctl.ground({{"base", {}}});
             REQUIRE(clingodl_prepare(theory, ctl.to_c()));

--- a/libclingo-dl/tests/solve.cc
+++ b/libclingo-dl/tests/solve.cc
@@ -151,7 +151,7 @@ TEST_CASE("solving", "[clingo]") {
 
             parse_program(theory, ctl,
                 "#program base.\n"
-                "&diff { a } >= \"0.5\"*3.\n"
+                "&diff { a } >= \"0.5\" * 3.\n"
                 );
             ctl.ground({{"base", {}}});
             REQUIRE(clingodl_prepare(theory, ctl.to_c()));
@@ -165,7 +165,7 @@ TEST_CASE("solving", "[clingo]") {
 
             parse_program(theory, ctl,
                 "#program base.\n"
-                "&diff { p(1+2)-q(3*4-7) } <= 3-\"9.0\".\n"
+                "&diff { p( 1 + 2 ) - q( 3 * 4 - 7 ) } <= 3 - \"9.0\".\n"
                 );
             ctl.ground({{"base", {}}});
             REQUIRE(clingodl_prepare(theory, ctl.to_c()));
@@ -197,8 +197,8 @@ TEST_CASE("solving", "[clingo]") {
 
             parse_program(theory, ctl,
                 "#program base.\n"
-                "a :- &diff {a-a} <= 5.\n"
-                "{b}.\n"
+                "a :- &diff { a - a } <= 5.\n"
+                "{ b }.\n"
                 "&diff {} < -4 :- b.\n"
                 );
             ctl.ground({{"base", {}}});


### PR DESCRIPTION
Regarding Issue #38 
Is there any form of linter that you use ?

> EDIT 1: You destroyed the call_visit method. It was using a static if but now is not anymore. The c++14 way to do this is to use std::enable_if.

You already did this.

> EDIT 2: I made it compile but there are still issues. Better not put anything in the top-level namespace. Anything that was in the Clingcon namespace should be in the ClingoDL namespace now. Do not use anonymous namespaces in header files. These really only make sense in source files. Otherwise you riddle the object files with duplicated functions. Also there where duplicate definitions of function definitions, which I simply declared inline now. My rule of thumb is that anything that is more than one or two lines goes into a C++ file.

Added ClingoDL namespace. Moved some stuff to cc files.

> EDIT 3: And the remaining [[nodiscard]] attributes have to be removed to compile on windows.

Done

Further suggestions ?