### PR TITLE
directly handle empty constraints

### DIFF
--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1301,9 +1301,7 @@ public:
             parse_constraint_elem(element.tuple().front(), covec);
         }
         auto rhs = simplify(covec);
-
         normalize_constraint(init, lit, covec, rel, rhs, strict);
-
     }
 
     bool add_edge(PropagateInit& init, int literal, CoVarVec const &covec, T rhs, bool strict) {
@@ -1785,8 +1783,7 @@ private:
         if (a.type() == Clingo::SymbolType::String) {
             return std::stod(a.string());
         }
-        check_syntax(false);
-        return static_cast<T>(0); // remove warning
+        return throw_syntax_error<T>();
     }
 
     template <class F, class N, typename std::enable_if<std::is_integral<N>::value, int>::type = 0>
@@ -1802,9 +1799,7 @@ private:
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &a, Clingo::TheoryTerm const &b, F f) const {
         auto ea = evaluate(a);
         auto eb = evaluate(b);
-        //TODO: does Clingo copy string ?
         return Clingo::String(std::to_string(f(to_T(ea), to_T(eb))).c_str());
-
     }
 
     template <class F>
@@ -1821,7 +1816,6 @@ private:
     T epsilon() const {
         return 0.00001;
     }
-
 
     Clingo::Symbol evaluate(Clingo::TheoryTerm const &term) const {
         if (term.type() == Clingo::TheoryTermType::Symbol) {
@@ -1872,10 +1866,8 @@ private:
             }
             return Clingo::Function(term.type() == Clingo::TheoryTermType::Function ? term.name() : "", args);
         }
-
         return throw_syntax_error<Clingo::Symbol>();
     }
-
 
 private:
 

--- a/libclingo-dl/clingo-dl/propagator.hh
+++ b/libclingo-dl/clingo-dl/propagator.hh
@@ -1316,7 +1316,15 @@ public:
         }
         auto u_id = map_vert(Clingo::Number(0));
         auto v_id = map_vert(Clingo::Number(0));
-        if (covec.size() == 1) {
+        if (covec.size() == 0) {
+            int eval_lit = (0 <= rhs) ? 1 : -1;
+            if (!init.add_clause({-literal, eval_lit})) return false;
+            if (strict) {
+                if (!init.add_clause({-eval_lit, -literal})) return false;
+            }
+            return true;
+        }
+        else if (covec.size() == 1) {
             if (covec[0].first == 1) {
                 u_id = covec[0].second;
             }

--- a/libclingo-dl/src/propagator.cc
+++ b/libclingo-dl/src/propagator.cc
@@ -155,7 +155,6 @@ struct TermTagger {
     }
 };
 
-
 // Tags head and body atoms and ensures multiset semantics.
 struct TheoryRewriter {
     // Add variables to tuple to ensure multiset semantics.

--- a/libclingo-dl/tests/solve.cc
+++ b/libclingo-dl/tests/solve.cc
@@ -190,6 +190,33 @@ TEST_CASE("solving", "[clingo]") {
             auto b = Id("b"),  c = Id("c"), d = Id("d"),  e = Id("e"), f = Id("f");
             REQUIRE(result == (ResultVec{{{a, 2},{b, 2},{c, 1},{d, 0},{e, 0}, {f, 1}},{{a, 2},{b, 2},{c, 1},{d, 0},{e, 1}, {f, 0}}}));
         }
+        SECTION("empty constraints") {
+            REQUIRE(clingodl_register(theory, ctl.to_c()));
+
+            parse_program(theory, ctl,
+                "#program base.\n"
+                "a :- &diff {a-a} <= 5.\n"
+                "{b}.\n"
+                "&diff {} < -4 :- b.\n"
+                );
+            ctl.ground({{"base", {}}});
+            REQUIRE(clingodl_prepare(theory, ctl.to_c()));
+
+            auto result = solve(theory, ctl);
+            REQUIRE(result == (ResultVec{{}}));
+            StatisticsType type= ctl.statistics().type();
+            if (type == StatisticsType::Value)
+                std::cout << "Value " << std::endl;
+            if (type == StatisticsType::Map)
+                std::cout << "Map " << std::endl;
+            if (type == StatisticsType::Array)
+                std::cout << "Array " << std::endl;
+            for (const auto i : ctl.statistics().keys()) {
+                std::cout << i << std::endl;
+            }
+//            REQUIRE(ctl.statistics()["solving"]["solvers"]["choices"] == 0);
+        }
+
 
         clingodl_destroy(theory);
     }

--- a/libclingo-dl/tests/solve.cc
+++ b/libclingo-dl/tests/solve.cc
@@ -21,7 +21,6 @@ public:
     , builder_{builder} {
     }
 
-
     static bool add_(clingo_ast_statement_t const *stm, void *data) {
         auto *self = static_cast<Rewriter*>(data);
         return clingo_program_builder_add(self->builder_, stm);
@@ -35,8 +34,6 @@ public:
     clingodl_theory_t *theory_;
     clingo_program_builder_t *builder_;
 };
-
-
 
 using ResultVec = std::vector<std::vector<std::pair<Clingo::Symbol, double>>>;
 ResultVec solve(clingodl_theory_t *theory, Clingo::Control &ctl) {
@@ -216,8 +213,6 @@ TEST_CASE("solving", "[clingo]") {
             }
 //            REQUIRE(ctl.statistics()["solving"]["solvers"]["choices"] == 0);
         }
-
-
         clingodl_destroy(theory);
     }
 }

--- a/libclingo-dl/tests/solve.cc
+++ b/libclingo-dl/tests/solve.cc
@@ -201,17 +201,7 @@ TEST_CASE("solving", "[clingo]") {
 
             auto result = solve(theory, ctl);
             REQUIRE(result == (ResultVec{{}}));
-            StatisticsType type= ctl.statistics().type();
-            if (type == StatisticsType::Value)
-                std::cout << "Value " << std::endl;
-            if (type == StatisticsType::Map)
-                std::cout << "Map " << std::endl;
-            if (type == StatisticsType::Array)
-                std::cout << "Array " << std::endl;
-            for (const auto i : ctl.statistics().keys()) {
-                std::cout << i << std::endl;
-            }
-//            REQUIRE(ctl.statistics()["solving"]["solvers"]["choices"] == 0);
+            REQUIRE(ctl.statistics()["solving"]["solvers"]["choices"] == 0);
         }
         clingodl_destroy(theory);
     }


### PR DESCRIPTION
Sorry for being stupid again.
I tried to handle empty constraints directly by not introducing them into the DLPropagator.
When writing the unit test I tried to check for choices=0.
To figure out where this statistic is hidden i tried to enumerate the keys of the statistics map.
Unfortunately, I do get a Segfault when trying to do so.
What is the intended behaviour to read out the statistics keys.